### PR TITLE
[ORB-49] OAuth Login via API 42 — Auth42 Gateway e Callback funcionando

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,50 +4,87 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
+
 	"github.com/orbit-alliance/orbit-backend/internal/application/user/services"
 	"github.com/orbit-alliance/orbit-backend/internal/domain/shared"
 	"github.com/orbit-alliance/orbit-backend/internal/domain/user"
 	"github.com/orbit-alliance/orbit-backend/internal/infra/db"
 	repo "github.com/orbit-alliance/orbit-backend/internal/infra/db/repos"
-	seed "github.com/orbit-alliance/orbit-backend/internal/infra/db/seeds"
 	"github.com/orbit-alliance/orbit-backend/internal/infra/web3"
+
+	seed "github.com/orbit-alliance/orbit-backend/internal/infra/db/seeds"
+
+	gateway_42 "github.com/orbit-alliance/orbit-backend/internal/infra/gateway"
+
+	usercontroller "github.com/orbit-alliance/orbit-backend/internal/interface/http/controllers/user"
+	"github.com/orbit-alliance/orbit-backend/internal/interface/http/routes"
 )
 
 func main() {
 
+	// Carrega as variáveis de ambiente do arquivo .env
 	err := godotenv.Load()
 	if err != nil {
 		log.Fatal("Erro ao carregar o arquivo .env", err)
 	}
 
+	// Obtém a porta da aplicação a partir das variáveis de ambiente
 	APP_PORT := os.Getenv("APP_PORT")
 	fmt.Println("Porta da aplicação: ", APP_PORT)
 
+	// Inicializa o banco de dados MongoDB
 	db.InitMongoDB()
 	defer db.CloseMongoDB()
 
+	// EventBus e gateways, criados para gerenciar eventos e interações com a blockchain
 	eventBus := shared.NewEventBus()
-	ethGateway, err := web3.NewEthGateway(64)
-	if err != nil {
-		log.Fatal("Erro ao criar o EthGateway", err)
-	}
+
+	// Cria o EthGateway mockado
+	ethGateway := web3.NewMockEthGateway()
+
+	// Cria o EthGateway para interações com a blockchain Ethereum
+	// ethGateway, err := web3.NewEthGateway(64)
+	// if err != nil {
+	// 	log.Fatal("Erro ao criar o EthGateway", err)
+	// }
+
+	// Cria o Api42Gateway para interações com a API da 42 de autenticação
+	auth42Gateway := gateway_42.NewGateway42()
+
+	// Repositórios para acessar os dados de usuários, transferências e ações de boas práticas
+	userRepo := repo.NewUserRepository(db.Database)
+	transferRepo := repo.NewTransferRepository(db.Database)
+	goodActionRepo := repo.NewGoodActionRepository(db.Database)
+
+	// Serviços que encapsulam a lógica de negócios
+	transferCoinsService := services.NewTransferCoinsService(userRepo, transferRepo, eventBus)
+	//register42Service := services.NewRegister42Service(userRepo, eventBus, auth42Gateway, ethGateway)
+
+	// Publicador de ações de boas práticas na blockchain
 	onChainPublisher := services.NewOnChainPublisher(ethGateway)
 	eventBus.Subscribe(user.DidGoodAction{}.EventType(), onChainPublisher.GoodActionPublisher)
 
-	goodActionRepo := repo.NewGoodActionRepository(db.Database)
-	userRepo := repo.NewUserRepository(db.Database)
-	transferRepo := repo.NewTransferRepository(db.Database)
-	transferCoinsService := services.NewTransferCoinsService(userRepo, transferRepo, eventBus)
-
+	// Inicializa o EthGateway para ouvir eventos de transferências
 	ethGateway.TransferListener(context.TODO(), func(event user.TransferDTO) {
 		if err := transferCoinsService.TransferCoins(event); err != nil {
 			log.Printf("Failed to transfer coins for event %+v: %v", event, err)
 		}
 	})
 
+	// Semente de dados iniciais para ações de boas práticas
 	seed.SeedGoodActions(context.TODO(), goodActionRepo)
 
+	// Handlers para as rotas de autenticação da 42
+	auth42Handler := usercontroller.NewAuth42Handler(auth42Gateway)
+	router := mux.NewRouter()
+	routes.RegisterUserRoutes(router, auth42Handler)
+
+	// Start HTTP server, para escutar na porta definida
+	fmt.Println("API Orbit rodando em http://localhost:" + APP_PORT)
+	log.Fatal(http.ListenAndServe(":"+APP_PORT, router))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.2
 
 require (
 	github.com/ethereum/go-ethereum v1.15.11
+	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
 	go.mongodb.org/mongo-driver v1.17.3
 )

--- a/internal/application/user/services/register_42.go
+++ b/internal/application/user/services/register_42.go
@@ -28,42 +28,42 @@ func NewRegister42Service(
 		ethGateway:   ethGateway,
 	}
 }
-func (s *Register42Service) Register42User(token42, walletAddress string) error {
-	ctx := context.Background()
+func (s *Register42Service) Register42User(ctx context.Context, token42, walletAddress string) (string, string, error) {
 
 	err := s.checkIfWalletAlreadyRegistered(ctx, walletAddress)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	ID42, login, err := s.api42Gateway.GetBasicUserInfo(ctx, token42)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	usr, err := s.userRepo.FindByID42(ctx, ID42)
 	if err != nil {
-		return err
+		return "", "", err
 	}
+
 	if usr != nil {
-		s.changeWalletAddress(ctx, usr, walletAddress)
-		return nil
+		err := s.changeWalletAddress(ctx, usr, walletAddress)
+		return ID42, login, err
 	}
 
 	coinStatus, err := s.ethGateway.GetCoinsStatusByWallet(ctx, walletAddress)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	usr = user.NewUser(shared.NewMongoID(), ID42, walletAddress, login, *coinStatus, []nft.NFT{})
 	err = s.userRepo.Save(ctx, usr)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	s.eventBus.Publish(ctx, user.NewUser42Registered(usr))
 
-	return nil
+	return ID42, login, nil
 }
 
 func (s *Register42Service) checkIfWalletAlreadyRegistered(ctx context.Context, wallet string) error {

--- a/internal/domain/user/gateway.go
+++ b/internal/domain/user/gateway.go
@@ -35,4 +35,5 @@ type Api42Gateway interface {
 	GetRetroactiveBonusProject(userID string) ([]UserProjectBonusDTO, error)
 	GetRetroactiveLoggedDays(userID string, startAt string) ([]UserLoggedDaysDTO, error)
 	GetBasicUserInfo(ctx context.Context, token string) (ID42 string, login string, err error)
+	ExchangeCodeForToken(ctx context.Context, code string) (string, error)
 }

--- a/internal/infra/gateway/exchange_code.go
+++ b/internal/infra/gateway/exchange_code.go
@@ -1,0 +1,61 @@
+package gateway_42
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+func (g *Gateway42) ExchangeCodeForToken(ctx context.Context, code string) (string, error) {
+	clientID := os.Getenv("CLIENT_ID_42")
+	clientSecret := os.Getenv("CLIENT_SECRET_42")
+	redirectURI := os.Getenv("REDIRECT_URI_42")
+
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.intra.42.fr/oauth/token",
+		strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Header Authorization → Basic base64(client_id:client_secret)
+	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", clientID, clientSecret)))
+	req.Header.Set("Authorization", "Basic "+auth)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("erro ao obter token: %s", string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", err
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("token inválido")
+	}
+
+	return tokenResp.AccessToken, nil
+}

--- a/internal/infra/gateway/get_auth_42.go
+++ b/internal/infra/gateway/get_auth_42.go
@@ -1,0 +1,44 @@
+package gateway_42
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (g *Gateway42) GetBasicUserInfo(ctx context.Context, token string) (string, string, error) {
+	url := "https://api.intra.42.fr/v2/me"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("erro na consulta ao /v2/me: %s", string(body))
+	}
+
+	var result struct {
+		ID    int    `json:"id"`
+		Login string `json:"login"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprint(result.ID), result.Login, nil
+}

--- a/internal/infra/web3/mock_eth_gateway.go
+++ b/internal/infra/web3/mock_eth_gateway.go
@@ -1,0 +1,34 @@
+package web3
+
+import (
+	"context"
+	"log"
+
+	"github.com/orbit-alliance/orbit-backend/internal/domain/coin"
+	"github.com/orbit-alliance/orbit-backend/internal/domain/user"
+)
+
+type MockEthGateway struct{}
+
+func NewMockEthGateway() *MockEthGateway {
+	return &MockEthGateway{}
+}
+
+func (m *MockEthGateway) PublishUserAction(ctx context.Context, payload *user.UserGoodAction) error {
+	log.Println("🪄 [Mock] PublishUserAction chamado → payload:", payload)
+	return nil
+}
+
+func (m *MockEthGateway) TransferListener(ctx context.Context, handler func(event user.TransferDTO)) error {
+	log.Println("🪄 [Mock] TransferListener iniciado → ouvindo nada, apenas mock")
+	return nil
+}
+
+func (m *MockEthGateway) GetCoinsStatusByWallet(ctx context.Context, wallet string) (*coin.CoinStatus, error) {
+	log.Println("🪄 [Mock] GetCoinsStatusByWallet chamado para wallet:", wallet)
+	// Retorna um estado de saldo fake
+	return &coin.CoinStatus{
+		EarnedByActions:  100,
+		EarnedByTransfer: 50,
+	}, nil
+}

--- a/internal/interface/http/controllers/user/auth_42_handler.go
+++ b/internal/interface/http/controllers/user/auth_42_handler.go
@@ -1,0 +1,73 @@
+package usercontroller
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/orbit-alliance/orbit-backend/internal/domain/user"
+)
+
+type Auth42Handler struct {
+	auth42Gateway user.Api42Gateway
+}
+
+func NewAuth42Handler(auth42Gateway user.Api42Gateway) *Auth42Handler {
+	return &Auth42Handler{
+		auth42Gateway: auth42Gateway,
+	}
+}
+
+// ➕ Redireciona para o login da 42
+func (h *Auth42Handler) Login(w http.ResponseWriter, r *http.Request) {
+	clientID := os.Getenv("CLIENT_ID_42")
+	redirectURI := os.Getenv("REDIRECT_URI_42")
+
+	if clientID == "" || redirectURI == "" {
+		log.Fatal("CLIENT_ID_42 ou REDIRECT_URI_42 não estão definidos")
+	}
+
+	authURL := fmt.Sprintf(
+		"https://api.intra.42.fr/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code",
+		clientID,
+		url.QueryEscape(redirectURI),
+	)
+
+	fmt.Println("Auth URL gerada:", authURL)
+
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// 🔥 Callback que recebe o code, troca pelo token e busca o user
+func (h *Auth42Handler) Callback(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "Código de autorização não encontrado", http.StatusBadRequest)
+		return
+	}
+
+	// 🪄 🔗 Usa o gateway para trocar o code por token
+	token, err := h.auth42Gateway.ExchangeCodeForToken(r.Context(), code)
+	if err != nil {
+		http.Error(w, "Erro ao obter token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 🔍 Consulta o user na API da 42
+	id42, login, err := h.auth42Gateway.GetBasicUserInfo(r.Context(), token)
+	if err != nil {
+		http.Error(w, "Erro ao obter dados do usuário: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 🟢 Retorna ID e Login
+	response := map[string]string{
+		"id42":  id42,
+		"login": login,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/internal/interface/http/routes/user_routes.go
+++ b/internal/interface/http/routes/user_routes.go
@@ -1,0 +1,14 @@
+package routes
+
+import (
+	"github.com/gorilla/mux"
+	usercontroller "github.com/orbit-alliance/orbit-backend/internal/interface/http/controllers/user"
+)
+
+// RegisterUserRoutes registra as rotas relacionadas ao usuário no roteador fornecido
+// e associa o Auth42Handler para lidar com as requisições de autenticação via 42.
+// Agora a função recebe o handler como parâmetro
+func RegisterUserRoutes(router *mux.Router, auth42Handler *usercontroller.Auth42Handler) {
+	router.HandleFunc("/auth/42/login", auth42Handler.Login).Methods("GET")
+	router.HandleFunc("/auth/42/callback", auth42Handler.Callback).Methods("GET")
+}


### PR DESCRIPTION
## **Pull Request — Implementação de Login via OAuth da API 42**

### Issue relacionada:

Closes #ORB-49


## **Descrição**

Implementação do fluxo de autenticação via OAuth2 utilizando a API oficial da 42. Este PR permite que o backend da Orbit Alliance realize a autenticação de usuários através de suas credenciais da Intra, retornando dados básicos do usuário (`id42` e `login`).


## **Principais entregas deste PR:**

### **Novas rotas implementadas:**

* **GET `/auth/42/login`**

  * Redireciona para a página de autenticação da 42.
* **GET `/auth/42/callback`**

  * Recebe o `code` de autorização da 42.
  * Realiza a troca pelo `access_token`.
  * Consulta o endpoint `/v2/me` da API da 42.
  * Retorna no formato:

    ```json
    {
      "id42": "id",
      "login": "user"
    }
    ```


### **Funcionalidades incluídas:**

* Implementação completa do fluxo OAuth2.
* Integração com a API da 42 para autenticação.
* Gateway para abstração da troca de código por token e consulta de dados do usuário.
* Validação de variáveis de ambiente:

  * `CLIENT_ID_42`
  * `CLIENT_SECRET_42`
  * `REDIRECT_URI_42`


## **Arquivos impactados:**

* `cmd/main.go`
* `go.mod`
* `internal/application/user/services/register_42.go`
* `internal/domain/user/gateway.go`
* `internal/infra/gateway/exchange_code.go`
* `internal/infra/gateway/get_auth_42.go`
* `internal/iinfra/web3/mock_eth_gateway.go`
* `internal/interface/http/controllers/user/auth_42_handler.go`
* `internal/interface/http/routes/user_routes.go`
* `.env` atualizado com as variáveis de integração da API 42


## **Evidências do funcionamento:**

### Fluxo:

1. Acesso à rota:
   → `http://localhost:8888/auth/42/login`
        ↳ Redireciona para a página de login da 42.

2. Login bem-sucedido → Redireciona para:
   → `http://localhost:8888/auth/42/callback?code=xxxxxx`

3. Retorno da API Orbit:

```json
{
  "id42": "164502",
  "login": "jparnahy"
}
```

### 📸 Print de sucesso:
![image](https://github.com/user-attachments/assets/071a5347-2aed-4851-84c1-73cdce774973)


## **Checklist**

* [x] Testado localmente.
* [x] Variáveis de ambiente funcionando (`CLIENT_ID_42`, `CLIENT_SECRET_42`, `REDIRECT_URI_42`).

<br> 

### **Observação**
*Para testar a implementação, ethGatewey mockado:*
*trecho da `main.go`*
```go
        // Cria o EthGateway mockado
	ethGateway := web3.NewMockEthGateway()

	// Cria o EthGateway para interações com a blockchain Ethereum
	// ethGateway, err := web3.NewEthGateway(64)
	// if err != nil {
	// 	log.Fatal("Erro ao criar o EthGateway", err)
	// }
```